### PR TITLE
Add default encoding to Write function

### DIFF
--- a/edittime.js
+++ b/edittime.js
@@ -81,6 +81,12 @@ AddAction(6, cf_none, "Show open dialog", "Dialog", "Open a dialog to chose a fi
 AddStringParam("Tag", "A unique tag to keep track of the result", "");
 AddStringParam("Path", "The path of the file to write", "");
 AddStringParam("Data", "The data to write", "");
+AddStringParam("Encoding", "The encoding of the file", "utf8");
+//TODO
+//AddComboParamOption("utf8");
+//AddComboParamOption("Binary");
+//AddComboParamOption("Base64");
+//AddComboParam("Encoding Mode", "Encoding mode.");
 AddAction(0, cf_none, "Write asynchronous", "Write", "Write {2} to {1} ({0})", "Write data to a specific file asynchronously", "Write");
 
 AddStringParam("Tag", "A unique tag to keep track of the result", "");

--- a/edittime.js
+++ b/edittime.js
@@ -81,12 +81,10 @@ AddAction(6, cf_none, "Show open dialog", "Dialog", "Open a dialog to chose a fi
 AddStringParam("Tag", "A unique tag to keep track of the result", "");
 AddStringParam("Path", "The path of the file to write", "");
 AddStringParam("Data", "The data to write", "");
-AddStringParam("Encoding", "The encoding of the file", "utf8");
-//TODO
-//AddComboParamOption("utf8");
-//AddComboParamOption("Binary");
-//AddComboParamOption("Base64");
-//AddComboParam("Encoding Mode", "Encoding mode.");
+AddComboParamOption("utf8");
+AddComboParamOption("Binary");
+AddComboParamOption("Base64");
+AddComboParam("Encoding Mode", "Encoding mode.");
 AddAction(0, cf_none, "Write asynchronous", "Write", "Write {2} to {1} ({0})", "Write data to a specific file asynchronously", "Write");
 
 AddStringParam("Tag", "A unique tag to keep track of the result", "");


### PR DESCRIPTION
A temp addparam encoding with default value "utf8" to Write function in order to fit to runtime function args